### PR TITLE
Feature: Implement music queue

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ import discord
 from discord.ext import commands
 import yt_dlp
 from os import getenv
-import asyncio
 
 # Read token from config.ini
 config = configparser.ConfigParser()
@@ -18,59 +17,56 @@ intents = discord.Intents.default()
 intents.message_content = True  # needed for text commands
 bot = commands.Bot(command_prefix="!", intents=intents)
 
-# Dictionary to store song queues for each server (guild)
-# Format: { guild_id: [url1, url2, ...] }
-queues = {}
+song_queue = []
 
-async def play_next_song(ctx):
-    """
-    A helper function that plays the next song in the queue for a given context's guild.
-    This function is called recursively by the 'after' parameter in voice_client.play().
-    """
-    guild_id = ctx.guild.id
-    if guild_id in queues and queues[guild_id]:
-        # Get the next song URL from the front of the queue
-        url = queues[guild_id].pop(0)
-        
-        # --- Audio fetching and playing logic ---
-        ydl_opts = {
-            'format': 'bestaudio/best',
-            'quiet': True,
-            'default_search': 'auto',
-            'extract_flat': 'in_playlist',
+async def play_next(ctx):
+    """A helper function that checks the queue and plays the next song."""
+    if song_queue:
+        # Get the next URL from the front of the queue
+        next_url = song_queue.pop(0)
+        await play_song(ctx, next_url)
+
+async def play_song(ctx, url: str):
+    """A helper function that contains the core logic for playing a song."""
+    voice_client = ctx.voice_client
+
+    ydl_opts = {
+        'format': 'bestaudio/best',
+        'quiet': True,
+        'default_search': 'auto',
+        'extract_flat': 'in_playlist',
+    }
+
+    # Sanitize URL to remove playlist parameters
+    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    # Remove playlist-related params
+    for param in ['list', 'start_radio', 'index', 'playlist', 'playnext', 'feature', 'si']:
+        qs.pop(param, None)
+    new_query = urlencode(qs, doseq=True)
+    sanitized_url = urlunparse(parsed._replace(query=new_query))
+
+    try:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(sanitized_url, download=False)
+            audio_url = info['url']
+            title = info.get('title', 'Unknown Title')
+
+        ffmpeg_options = {
+            'options': '-vn'  # no video
         }
 
-        # Sanitize URL to remove playlist parameters
-        from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-        parsed = urlparse(url)
-        qs = parse_qs(parsed.query)
-        for param in ['list', 'start_radio', 'index', 'playlist', 'playnext', 'feature', 'si']:
-            qs.pop(param, None)
-        new_query = urlencode(qs, doseq=True)
-        sanitized_url = urlunparse(parsed._replace(query=new_query))
+        source = await discord.FFmpegOpusAudio.from_probe(audio_url, **ffmpeg_options)
+        # The 'after' callback now triggers the play_next function to handle the queue
+        voice_client.play(source, after=lambda e: bot.loop.create_task(play_next(ctx)))
+        await ctx.send(f"🎶 Now playing: **{title}**")
 
-        try:
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                info = ydl.extract_info(sanitized_url, download=False)
-                audio_url = info['url']
-                title = info.get('title', 'Unknown Title')
-
-            ffmpeg_options = {
-                'options': '-vn'  # no video
-            }
-
-            source = await discord.FFmpegOpusAudio.from_probe(audio_url, **ffmpeg_options)
-            
-            # The 'after' callback schedules this same function to run again, playing the next song
-            ctx.voice_client.play(source, after=lambda e: asyncio.run_coroutine_threadsafe(play_next_song(ctx), bot.loop))
-            
-            await ctx.send(f"🎶 Now playing: **{title}**")
-
-        except Exception as e:
-            print(f"Error playing song: {e}")
-            await ctx.send(f"An error occurred while trying to play the song. Skipping.")
-            # If an error occurs, try to play the next song in the queue
-            await play_next_song(ctx)
+    except Exception as e:
+        print(f"Error playing song: {e}")
+        await ctx.send(f"❌ An error occurred while trying to play this song.")
+        # If something goes wrong, try to play the next song in the queue
+        await play_next(ctx)
 
 @bot.event
 async def on_ready():
@@ -93,50 +89,31 @@ async def join(ctx):
 
 @bot.command()
 async def play(ctx, *, url: str):
-    """Plays audio from a YouTube link or adds it to the queue."""
+    """Plays audio from a link or adds it to the queue."""
     voice_client = ctx.voice_client
     if voice_client is None:
         await ctx.send("I'm not in a voice channel! Use `!join` first.")
         return
 
-    guild_id = ctx.guild.id
-    
-    # Get or create the queue for this guild
-    guild_queue = queues.setdefault(guild_id, [])
-    guild_queue.append(url)
-
-    if not voice_client.is_playing():
-        # If nothing is playing, start the player
-        await play_next_song(ctx)
+    # If the bot is already playing something, add the new song to the queue
+    if voice_client.is_playing() or voice_client.is_paused():
+        song_queue.append(url)
+        await ctx.send(f"👍 Added to queue: `{url}`")
     else:
-        # If something is already playing, just confirm the song was added
-        await ctx.send(f"👍 Added to queue!")
-
-
-@bot.command()
-async def skip(ctx):
-    """Skips to the next song in the queue."""
-    voice_client = ctx.voice_client
-    if voice_client and voice_client.is_playing():
-        # Stopping the current song will trigger the 'after' callback,
-        # which in turn calls play_next_song() to play the next item.
-        voice_client.stop()
-        await ctx.send("⏭️ Skipped!")
-    else:
-        await ctx.send("I'm not playing anything to skip.")
+        # If nothing is playing, start playing the requested song immediately
+        await play_song(ctx, url)
 
 
 @bot.command()
 async def leave(ctx):
     """Leaves the current voice channel and clears the queue."""
+    global song_queue
     voice_client = ctx.voice_client
     if voice_client is not None:
-        # Clear the queue for this guild before leaving
-        if ctx.guild.id in queues:
-            queues.pop(ctx.guild.id)
-            
+        # Clear the queue when the bot leaves
+        song_queue = []
         await voice_client.disconnect()
-        await ctx.send("👋 Left the voice channel.")
+        await ctx.send("👋 Left the voice channel and cleared the queue.")
     else:
         await ctx.send("I'm not in a voice channel!")
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 import yt_dlp
 from os import getenv
+import asyncio
 
 # Read token from config.ini
 config = configparser.ConfigParser()
@@ -16,6 +17,60 @@ else:
 intents = discord.Intents.default()
 intents.message_content = True  # needed for text commands
 bot = commands.Bot(command_prefix="!", intents=intents)
+
+# Dictionary to store song queues for each server (guild)
+# Format: { guild_id: [url1, url2, ...] }
+queues = {}
+
+async def play_next_song(ctx):
+    """
+    A helper function that plays the next song in the queue for a given context's guild.
+    This function is called recursively by the 'after' parameter in voice_client.play().
+    """
+    guild_id = ctx.guild.id
+    if guild_id in queues and queues[guild_id]:
+        # Get the next song URL from the front of the queue
+        url = queues[guild_id].pop(0)
+        
+        # --- Audio fetching and playing logic ---
+        ydl_opts = {
+            'format': 'bestaudio/best',
+            'quiet': True,
+            'default_search': 'auto',
+            'extract_flat': 'in_playlist',
+        }
+
+        # Sanitize URL to remove playlist parameters
+        from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+        parsed = urlparse(url)
+        qs = parse_qs(parsed.query)
+        for param in ['list', 'start_radio', 'index', 'playlist', 'playnext', 'feature', 'si']:
+            qs.pop(param, None)
+        new_query = urlencode(qs, doseq=True)
+        sanitized_url = urlunparse(parsed._replace(query=new_query))
+
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(sanitized_url, download=False)
+                audio_url = info['url']
+                title = info.get('title', 'Unknown Title')
+
+            ffmpeg_options = {
+                'options': '-vn'  # no video
+            }
+
+            source = await discord.FFmpegOpusAudio.from_probe(audio_url, **ffmpeg_options)
+            
+            # The 'after' callback schedules this same function to run again, playing the next song
+            ctx.voice_client.play(source, after=lambda e: asyncio.run_coroutine_threadsafe(play_next_song(ctx), bot.loop))
+            
+            await ctx.send(f"🎶 Now playing: **{title}**")
+
+        except Exception as e:
+            print(f"Error playing song: {e}")
+            await ctx.send(f"An error occurred while trying to play the song. Skipping.")
+            # If an error occurs, try to play the next song in the queue
+            await play_next_song(ctx)
 
 @bot.event
 async def on_ready():
@@ -38,51 +93,48 @@ async def join(ctx):
 
 @bot.command()
 async def play(ctx, *, url: str):
-    """Plays audio from a YouTube link."""
+    """Plays audio from a YouTube link or adds it to the queue."""
     voice_client = ctx.voice_client
     if voice_client is None:
         await ctx.send("I'm not in a voice channel! Use `!join` first.")
         return
 
-    # Stop current audio if playing
-    if voice_client.is_playing():
+    guild_id = ctx.guild.id
+    
+    # Get or create the queue for this guild
+    guild_queue = queues.setdefault(guild_id, [])
+    guild_queue.append(url)
+
+    if not voice_client.is_playing():
+        # If nothing is playing, start the player
+        await play_next_song(ctx)
+    else:
+        # If something is already playing, just confirm the song was added
+        await ctx.send(f"👍 Added to queue!")
+
+
+@bot.command()
+async def skip(ctx):
+    """Skips to the next song in the queue."""
+    voice_client = ctx.voice_client
+    if voice_client and voice_client.is_playing():
+        # Stopping the current song will trigger the 'after' callback,
+        # which in turn calls play_next_song() to play the next item.
         voice_client.stop()
-
-    ydl_opts = {
-        'format': 'bestaudio/best',
-        'quiet': True,
-        'default_search': 'auto',
-        'extract_flat': 'in_playlist',
-    }
-
-    # Sanitize URL to remove playlist parameters
-    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-    parsed = urlparse(url)
-    qs = parse_qs(parsed.query)
-    # Remove playlist-related params
-    for param in ['list', 'start_radio', 'index', 'playlist', 'playnext', 'feature', 'si']:
-        qs.pop(param, None)
-    new_query = urlencode(qs, doseq=True)
-    sanitized_url = urlunparse(parsed._replace(query=new_query))
-
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-        info = ydl.extract_info(sanitized_url, download=False)
-        audio_url = info['url']
-
-    ffmpeg_options = {
-        'options': '-vn'  # no video
-    }
-
-    source = await discord.FFmpegOpusAudio.from_probe(audio_url, **ffmpeg_options)
-    voice_client.play(source, after=lambda e: print(f"Playback finished: {e}"))
-    await ctx.send(f"🎶 Now playing: **{info.get('title', 'Unknown Title')}**")
+        await ctx.send("⏭️ Skipped!")
+    else:
+        await ctx.send("I'm not playing anything to skip.")
 
 
 @bot.command()
 async def leave(ctx):
-    """Leaves the current voice channel."""
+    """Leaves the current voice channel and clears the queue."""
     voice_client = ctx.voice_client
     if voice_client is not None:
+        # Clear the queue for this guild before leaving
+        if ctx.guild.id in queues:
+            queues.pop(ctx.guild.id)
+            
         await voice_client.disconnect()
         await ctx.send("👋 Left the voice channel.")
     else:


### PR DESCRIPTION
This PR introduces a basic song queue system to the music bot. Users can now add songs to a queue while another song is playing, and they will be played in the order they were added.

---

### Changes

* **Queue Implementation**:
    * A new global list, `song_queue`, has been added to manage upcoming songs.

* **`!play` Command Logic**:
    * The `!play` command now checks if the bot is currently playing audio.
    * If a song is playing, the new request is appended to `song_queue`.
    * If the bot is idle, the requested song is played immediately.

* **Queue Processing**:
    * The core song-playing logic has been refactored into a `play_song` helper function.
    * A new `play_next` function is called via the `after` callback when a song finishes. This function checks the queue and plays the next song if available.

* **`!leave` Command Update**:
    * The `!leave` command now clears the `song_queue` to ensure a clean state when the bot disconnects.

---

### How to Test

1.  Run the bot and have it join a voice channel using the `!join` command.
2.  Start playing a song with `!play <youtube_url_1>`.
3.  While the first song is playing, add a second song using `!play <youtube_url_2>`.
4.  **Verify** that the bot responds with an "Added to queue" message.
5.  Wait for the first song to finish.
6.  **Verify** that the second song starts playing automatically.
7.  Use the `!leave` command.
8.  **Verify** that the bot disconnects and confirms that the queue has been cleared.